### PR TITLE
Format code using prettier, update node build target

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[src/*.ts]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+max_line_length = 80

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [14.x]
+                node-version: [18.x, 20.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3.8.1
+      - name: Clean NPM install
+        run: npm clean-install
+      - name: Check with prettier
+        run: npm run check-prettier

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "jsdom": "^22.1.0",
         "mock-socket": "^9.2.1",
         "npm-upgrade": "^3.1.0",
+        "prettier": "^3.0.3",
         "ts-jest": "^29.1.0",
         "typescript": "^5.1.3"
       }
@@ -6428,6 +6429,21 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -12972,6 +12988,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "jsdom": "^22.1.0",
     "mock-socket": "^9.2.1",
     "npm-upgrade": "^3.1.0",
+    "prettier": "^3.0.3",
     "ts-jest": "^29.1.0",
     "typescript": "^5.1.3"
   },
@@ -24,7 +25,9 @@
     "build": "npx tsc --project tsconfig.json",
     "watch": "npx tsc --project tsconfig.json --watch",
     "cover": "npx jest --coverage --coverageReporters=text-lcov | coveralls",
-    "test": "npx jest --coverage"
+    "test": "npx jest --coverage",
+    "prettier": "prettier src --write",
+    "check-prettier": "prettier src --check"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
 // File Dependencies
-import { WS_EVENT_NAMES, DATA_STORAGE_TYPES, DEFAULT_EVENT_LISTENERS_OBJECT } from "./lib/constants";
+import {
+  WS_EVENT_NAMES,
+  DATA_STORAGE_TYPES,
+  DEFAULT_EVENT_LISTENERS_OBJECT,
+} from "./lib/constants";
 import { serialize, deserialize } from "./lib/dataTransformer";
-import { PartialEventListenersInterface, EventListenersInterface } from "./lib/validators";
+import {
+  PartialEventListenersInterface,
+  EventListenersInterface,
+} from "./lib/validators";
 
 interface StorageParams {
   storageType: string;
@@ -93,7 +100,7 @@ export default class Sarus {
       retryProcessTimePeriod, // TODO - write a test case to check this
       retryConnectionDelay,
       storageType = "memory",
-      storageKey = "sarus"
+      storageKey = "sarus",
     } = props;
 
     this.eventListeners = this.auditEventListeners(eventListeners);
@@ -246,15 +253,14 @@ export default class Sarus {
       error: [],
       close: [],
     };
-  
+
     const mergedEventListeners: EventListenersInterface = {
       ...defaultEventListeners,
       ...eventListeners,
     } as EventListenersInterface; // Type assertion added here
-  
+
     return mergedEventListeners;
   }
-  
 
   /**
    * Connects the WebSocket client, and attaches event listeners
@@ -310,7 +316,7 @@ export default class Sarus {
     const eventFunctions = this.eventListeners[eventName];
     if (eventFunctions && eventFunctions.indexOf(eventFunc) !== -1) {
       throw new Error(
-        `${eventFunc.name} has already been added to this event Listener`
+        `${eventFunc.name} has already been added to this event Listener`,
       );
     }
     if (eventFunctions && eventFunctions instanceof Array) {
@@ -347,7 +353,7 @@ export default class Sarus {
       | {
           doNotThrowError: boolean;
         }
-      | undefined
+      | undefined,
   ) {
     if (!existingFunc) {
       if (!(opts && opts.doNotThrowError)) {
@@ -366,7 +372,7 @@ export default class Sarus {
   off(
     eventName: string,
     eventFuncOrName: Function | string,
-    opts?: { doNotThrowError: boolean } | undefined
+    opts?: { doNotThrowError: boolean } | undefined,
   ) {
     const existingFunc = this.findFunction(eventName, eventFuncOrName);
     if (existingFunc) {
@@ -421,7 +427,7 @@ export default class Sarus {
    */
   attachEventListeners() {
     const self: any = this;
-    WS_EVENT_NAMES.forEach(eventName => {
+    WS_EVENT_NAMES.forEach((eventName) => {
       self.ws[`on${eventName}`] = (e: Function) => {
         self.eventListeners[eventName].forEach((f: Function) => f(e));
         if (eventName === "close" && self.reconnectAutomatically) {
@@ -433,16 +439,16 @@ export default class Sarus {
   }
 
   /**
-   * Removes the event listeners from a closed WebSocket instance, so that 
+   * Removes the event listeners from a closed WebSocket instance, so that
    * they are cleaned up
    */
   removeEventListeners() {
     const self: any = this;
-    WS_EVENT_NAMES.forEach(eventName => {
+    WS_EVENT_NAMES.forEach((eventName) => {
       if (self.ws.listeners && self.ws.listeners[eventName]) {
-        self.ws.listeners[eventName].forEach((iel:Function) => {
+        self.ws.listeners[eventName].forEach((iel: Function) => {
           self.ws.removeEventListener(eventName, iel);
-        })
+        });
       }
     });
   }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,7 +10,7 @@ export const WS_EVENT_NAMES: Array<string> = [
   "open",
   "close",
   "message",
-  "error"
+  "error",
 ];
 
 /**
@@ -34,5 +34,5 @@ export const DEFAULT_EVENT_LISTENERS_OBJECT: EventListenersInterface = {
   open: [],
   message: [],
   error: [],
-  close: []
+  close: [],
 };


### PR DESCRIPTION
Hi,

I am proposing two changes:

- Format the code using prettier and enforce as part of GH workflows (rest assured, changes are minor).
- Update the node.js build target to reflect current and LTS as of today (it will change again in October)

Do I understand correctly that you expect contributions to come in as MIT licensed? If so, could you direct me to where authors are credited?

I am eager to help fix the constructor stack trace issue next!

Best,
Justus