### PR TITLE
Validate URLs when constructing Sarus object

### DIFF
--- a/__tests__/index/connectionOptions.test.ts
+++ b/__tests__/index/connectionOptions.test.ts
@@ -18,6 +18,26 @@ describe("connection options", () => {
     server.close();
   });
 
+  it("should correctly validate invalid WebSocket URLs", () => {
+    // Testing with jest-websocket-mock will not give us a TypeError here.
+    // We re-throw the error therefore. Testing it in a browser we can
+    // see that a TypeError is handled correctly.
+    expect(() => {
+      new Sarus({ url: "invalid-url" });
+    }).toThrow("invalid");
+
+    expect(() => {
+      new Sarus({ url: "http://wrong-protocol" });
+    }).toThrow("have protocol");
+
+    expect(() => {
+      new Sarus({ url: "https://also-wrong-protocol" });
+    }).toThrow("have protocol");
+
+    new Sarus({ url: "ws://this-will-pass" });
+    new Sarus({ url: "wss://this-too-shall-pass" });
+  });
+
   it("should set the WebSocket protocols value to an empty string if nothing is passed", async () => {
     const sarus: Sarus = new Sarus({ url });
     await server.connected;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,8 @@
 // Dependencies
 import { EventListenersInterface } from "./validators";
 
+export const ALLOWED_PROTOCOLS: Array<string> = ["ws:", "wss:"];
+
 /**
  * A definitive list of events for a WebSocket client to listen on
  * @constant


### PR DESCRIPTION
This will better inform a user about invalid URLs when constructing a new Sarus object. It will already give an error during construction instead of the connect step. That way, we won't repeatedly try to connect to the same URL, despite it being invalid the whole time.

Add test case in __tests__ for

- Completely invalid URL (fails to be fed into new URL())
- Invalid protocol (must be ws / wss)

We use stock JS functionality for this, so no custom URL parser.

This should fix #370.

Please let me know if you have any preferences regarding testing, like splitting each new Sarus() case into a separate test case.

Note that this changed the type of `this.url`. If this is only ever used internally, it shouldn't cause any problems. On the other hand if a consumer of a Sarus object depends on the datatype of this.url, it might be better to keep it as `string`. Having it a proper URL type prevents us from doing anything silly with it. Let me know what you think about this particular change.