### PR TITLE
Run commands in package.json directly, without npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "typescript": "^5.1.3"
   },
   "scripts": {
-    "build": "npx tsc --project tsconfig.json",
-    "watch": "npx tsc --project tsconfig.json --watch",
-    "cover": "npx jest --coverage --coverageReporters=text-lcov | coveralls",
-    "test": "npx jest --coverage",
+    "build": "tsc --project tsconfig.json",
+    "watch": "tsc --project tsconfig.json --watch",
+    "cover": "jest --coverage --coverageReporters=text-lcov | coveralls",
+    "test": "jest --coverage",
     "prettier": "prettier src __tests__ --write",
     "check-prettier": "prettier src __tests__ --check"
   },


### PR DESCRIPTION
If a user forgets to run npm install when running any of the scripts, npx will prompt the user if they want to install jest or tsc. If they type yes and let npx install jest, the remainder of the command will still fail since other dependencies are not installed automatically.

Furthermore, `npx tsc` will not even install the correct `typescript` package and instead give a warning like this:

```
> npx tsc --project tsconfig.json

                This is not the tsc command you are looking for

To get access to the TypeScript compiler, tsc, from the command line either:

- Use npm install typescript to first add TypeScript to your project before using npx
- Use yarn to avoid accidentally running code from un-installed packages
```

Removing each `npx` in the package.json scripts section remedies this issue.