### PR TITLE
Exponential backoff on reconnection attempts

### DIFF
--- a/__tests__/index/retryConnectionDelay.test.ts
+++ b/__tests__/index/retryConnectionDelay.test.ts
@@ -68,71 +68,74 @@ describe("Exponential backoff delay", () => {
   describe("with rate 2, backoffLimit 8000 ms", () => {
     // The initial delay shall be 1 s
     const initialDelay = 1000;
-    const exponentialBackoffParams: ExponentialBackoffParams = {
+    const exponentialBackoff: ExponentialBackoffParams = {
       backoffRate: 2,
       // We put the ceiling at exactly 8000 ms
       backoffLimit: 8000,
     };
+    const attempts: [number, number][] = [
+      [1000, 0],
+      [2000, 1],
+      [4000, 2],
+      [8000, 3],
+      [8000, 4],
+    ];
     it("will never be more than 8000 ms with rate set to 2", () => {
-      expect(
-        calculateRetryDelayFactor(exponentialBackoffParams, initialDelay, 0),
-      ).toBe(1000);
-      expect(
-        calculateRetryDelayFactor(exponentialBackoffParams, initialDelay, 1),
-      ).toBe(2000);
-      expect(
-        calculateRetryDelayFactor(exponentialBackoffParams, initialDelay, 2),
-      ).toBe(4000);
-      expect(
-        calculateRetryDelayFactor(exponentialBackoffParams, initialDelay, 3),
-      ).toBe(8000);
-      expect(
-        calculateRetryDelayFactor(exponentialBackoffParams, initialDelay, 4),
-      ).toBe(8000);
+      attempts.forEach(([delay, failedAttempts]) => {
+        expect(
+          calculateRetryDelayFactor(
+            exponentialBackoff,
+            initialDelay,
+            failedAttempts,
+          ),
+        ).toBe(delay);
+      });
     });
 
     it("should delay reconnection attempts exponentially", async () => {
+      // Somehow we need to convincen typescript here that "WebSocket" is
+      // totally valid. Could be because it doesn't assume WebSocket is part of
+      // global / the index key is missing
       const webSocketSpy = jest.spyOn(global, "WebSocket" as any);
       webSocketSpy.mockImplementation(() => {});
       const setTimeoutSpy = jest.spyOn(global, "setTimeout");
-      const sarus = new Sarus({
-        url,
-        exponentialBackoff: exponentialBackoffParams,
-      });
+      const sarus = new Sarus({ url, exponentialBackoff });
       expect(sarus.state).toStrictEqual({
         kind: "connecting",
         failedConnectionAttempts: 0,
       });
       let instance: WebSocket;
+      // Get the first WebSocket instance, and ...
       [instance] = webSocketSpy.mock.instances;
       if (!instance.onopen) {
         throw new Error();
       }
+      // tell the sarus instance that it is open, and ...
       instance.onopen(new Event("open"));
       if (!instance.onclose) {
         throw new Error();
       }
+      // close it immediately
       instance.onclose(new CloseEvent("close"));
+      expect(sarus.state).toStrictEqual({
+        kind: "closed",
+        failedConnectionAttempts: 0,
+      });
 
       let cb: Sarus["connect"];
       // We iteratively call sarus.connect() and let it fail, seeing
       // if it reaches 8000 as a delay and stays there
-      const attempts: [number, number][] = [
-        [1000, 1],
-        [2000, 2],
-        [4000, 3],
-        [8000, 4],
-        [8000, 5],
-      ];
-      attempts.forEach(([delay, failedAttempts]: [number, number]) => {
+      attempts.forEach(([delay, failedAttempts]) => {
         const call =
           setTimeoutSpy.mock.calls[setTimeoutSpy.mock.calls.length - 1];
         if (!call) {
           throw new Error();
         }
+        // Make sure that setTimeout was called with the correct delay
         expect(call[1]).toBe(delay);
         cb = call[0];
         cb();
+        // Get the most recent WebSocket instance
         instance =
           webSocketSpy.mock.instances[webSocketSpy.mock.instances.length - 1];
         if (!instance.onclose) {
@@ -141,7 +144,7 @@ describe("Exponential backoff delay", () => {
         instance.onclose(new CloseEvent("close"));
         expect(sarus.state).toStrictEqual({
           kind: "connecting",
-          failedConnectionAttempts: failedAttempts,
+          failedConnectionAttempts: failedAttempts + 1,
         });
       });
     });

--- a/__tests__/index/retryConnectionDelay.test.ts
+++ b/__tests__/index/retryConnectionDelay.test.ts
@@ -119,7 +119,6 @@ describe("Exponential backoff delay", () => {
       instance.onclose(new CloseEvent("close"));
       expect(sarus.state).toStrictEqual({
         kind: "closed",
-        failedConnectionAttempts: 0,
       });
 
       let cb: Sarus["connect"];

--- a/__tests__/index/state.test.ts
+++ b/__tests__/index/state.test.ts
@@ -15,27 +15,27 @@ describe("state machine", () => {
 
     // In the beginning, the state is "connecting"
     const sarus: Sarus = new Sarus(sarusConfig);
-    expect(sarus.state).toBe("connecting");
+    expect(sarus.state.kind).toBe("connecting");
 
     // We wait until we are connected, and see a "connected" state
     await server.connected;
-    expect(sarus.state).toBe("connected");
+    expect(sarus.state.kind).toBe("connected");
 
     // When the connection drops, the state will be "closed"
     server.close();
     await server.closed;
-    expect(sarus.state).toBe("closed");
+    expect(sarus.state.kind).toBe("closed");
 
     // Restart server
     server = new WS(url);
 
     // We wait a while, and the status is "connecting" again
     await delay(1);
-    expect(sarus.state).toBe("connecting");
+    expect(sarus.state.kind).toBe("connecting");
 
     // When we connect in our mock server, we are "connected" again
     await server.connected;
-    expect(sarus.state).toBe("connected");
+    expect(sarus.state.kind).toBe("connected");
 
     // Cleanup
     server.close();
@@ -46,23 +46,23 @@ describe("state machine", () => {
 
     // Same initial state transition as above
     const sarus: Sarus = new Sarus(sarusConfig);
-    expect(sarus.state).toBe("connecting");
+    expect(sarus.state.kind).toBe("connecting");
     await server.connected;
-    expect(sarus.state).toBe("connected");
+    expect(sarus.state.kind).toBe("connected");
 
     // The user can disconnect and the state will be "disconnected"
     sarus.disconnect();
-    expect(sarus.state).toBe("disconnected");
+    expect(sarus.state.kind).toBe("disconnected");
     await server.closed;
 
     // The user can now reconnect, and the state will be "connecting", and then
     // "connected" again
     sarus.connect();
-    expect(sarus.state).toBe("connecting");
+    expect(sarus.state.kind).toBe("connecting");
     await server.connected;
     // XXX for some reason the test will fail without waiting 10 ms here
     await delay(10);
-    expect(sarus.state).toBe("connected");
+    expect(sarus.state.kind).toBe("connected");
     server.close();
   });
 });

--- a/__tests__/index/state.test.ts
+++ b/__tests__/index/state.test.ts
@@ -31,7 +31,6 @@ describe("state machine", () => {
     await server.closed;
     expect(sarus.state).toStrictEqual({
       kind: "closed",
-      failedConnectionAttempts: 0,
     });
 
     // We wait a while, and the status is "connecting" again

--- a/src/index.ts
+++ b/src/index.ts
@@ -492,7 +492,7 @@ export default class Sarus {
   attachEventListeners() {
     const self: any = this;
     WS_EVENT_NAMES.forEach((eventName) => {
-      self.ws[`on${eventName}`] = (e: Function) => {
+      self.ws[`on${eventName}`] = (e: Event | CloseEvent | MessageEvent) => {
         self.eventListeners[eventName].forEach((f: Function) => f(e));
         if (eventName === "open") {
           self.state = { kind: "connected" };

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,10 +182,7 @@ export default class Sarus {
     | { kind: "connecting"; failedConnectionAttempts: number }
     | { kind: "connected" }
     | { kind: "disconnected" }
-    /**
-     * The closed state carries of the number of failed connection attempts
-     */
-    | { kind: "closed"; failedConnectionAttempts: number } = {
+    | { kind: "closed" } = {
     kind: "connecting",
     failedConnectionAttempts: 0,
   };
@@ -383,18 +380,9 @@ export default class Sarus {
    * Connects the WebSocket client, and attaches event listeners
    */
   connect() {
-    if (this.state.kind === "closed") {
-      this.state = {
-        kind: "connecting",
-        failedConnectionAttempts: this.state.failedConnectionAttempts,
-      };
-    } else if (
-      this.state.kind === "connected" ||
-      this.state.kind === "disconnected"
-    ) {
+    // If we aren't already connecting, we are now
+    if (this.state.kind !== "connecting") {
       this.state = { kind: "connecting", failedConnectionAttempts: 0 };
-    } else {
-      // This is a NOOP, we are already connecting
     }
     this.ws = new WebSocket(this.url, this.protocols);
     this.setBinaryType();
@@ -586,7 +574,7 @@ export default class Sarus {
           } else {
             // If we were in a different state, we assume that our connection
             // freshly closed and have not made any failed connection attempts.
-            self.state = { kind: "closed", failedConnectionAttempts: 0 };
+            self.state = { kind: "closed" };
           }
           self.removeEventListeners();
           self.reconnect();

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,11 @@ const validateWebSocketUrl = (rawUrl: string): URL => {
   return url;
 };
 
+export interface ExponentialBackoffParams {
+  backoffRate: number;
+  backoffLimit: number;
+}
+
 export interface SarusClassParams {
   url: string;
   binaryType?: BinaryType;
@@ -81,6 +86,7 @@ export interface SarusClassParams {
   retryProcessTimePeriod?: number;
   reconnectAutomatically?: boolean;
   retryConnectionDelay?: boolean | number;
+  exponentialBackoff?: ExponentialBackoffParams;
   storageType?: string;
   storageKey?: string;
 }
@@ -95,7 +101,8 @@ export interface SarusClassParams {
  * @param {object} param0.eventListeners - An optional object containing event listener functions keyed to websocket events
  * @param {boolean} param0.reconnectAutomatically - An optional boolean flag to indicate whether to reconnect automatically when a websocket connection is severed
  * @param {number} param0.retryProcessTimePeriod - An optional number for how long the time period between retrying to send a messgae to a WebSocket server should be
- * @param {number} param0.retryConnectionDelay - A parameter for the amount of time to delay a reconnection attempt by, in miliseconds.
+ * @param {boolean|number} param0.retryConnectionDelay - An optional parameter for whether to delay WebSocket reconnection attempts by a time period. If true, the delay is 1000ms, otherwise it is the number passed. The default value when this parameter is undefined will be interpreted as 1000ms.
+ * @param {ExponentialBackoffParams} param0.exponentialBackoff - An optional containing configuration for exponential backoff. If this parameter is undefined, exponential backoff is disabled. The minimum delay is determined by retryConnectionDelay. If retryConnectionDelay is set is false, this setting will not be in effect.
  * @param {string} param0.storageType - An optional string specifying the type of storage to use for persisting messages in the message queue
  * @param {string} param0.storageKey - An optional string specifying the key used to store the messages data against in sessionStorage/localStorage
  * @returns {object} The class instance
@@ -109,6 +116,7 @@ export default class Sarus {
   retryProcessTimePeriod?: number;
   reconnectAutomatically?: boolean;
   retryConnectionDelay: number;
+  exponentialBackoff?: ExponentialBackoffParams;
   storageType: string;
   storageKey: string;
 
@@ -164,6 +172,7 @@ export default class Sarus {
       reconnectAutomatically,
       retryProcessTimePeriod, // TODO - write a test case to check this
       retryConnectionDelay,
+      exponentialBackoff,
       storageType = "memory",
       storageKey = "sarus",
     } = props;
@@ -207,6 +216,13 @@ export default class Sarus {
       (typeof retryConnectionDelay === "boolean"
         ? undefined
         : retryConnectionDelay) ?? 1000;
+
+    /*
+      When a exponential backoff parameter object is provided, reconnection
+      attemptions will be increasingly delayed by an exponential factor.
+      This feature is disabled by default.
+    */
+    this.exponentialBackoff = exponentialBackoff;
 
     /*
       Sets the storage type for the messages in the message queue. By default


### PR DESCRIPTION
DEPENDS ON #402 

DEPENDS ON implementation of a state machine, or other means to track if connection is failing.

The problem: reconnecting with a default delay of 1s can result in a lot of additional traffic on a server.

Scenario:
1. N users are connecting to an endpoint using websockets with sarus
2. All N users lose authorization to access said websocket
3. All N users will now try to reconnect to this endpoint with a 403 returning every second
4. Server load is increased

The solution is to implement exponential backoff. Please refer to the readme for an exact description.

Question to @paulbjensen: If a connection is failing, I need to track the amount of failed connection attempts. To do that, I first need to know if a connection is failing. A state machine is usually a good idea to track the current state of a connection. I will prepare another to PR to lay the groundwork for this PR here. Do you have any other idea on how to implement this/is there anything else I can use in the code?